### PR TITLE
Fixed elytra autoequip

### DIFF
--- a/src/main/java/com/biel/lobby/utilities/Utils.java
+++ b/src/main/java/com/biel/lobby/utilities/Utils.java
@@ -108,7 +108,7 @@ public class Utils {
 		if(matstr.contains("HELMET")){
 			slot = 3;
 		}
-		if(matstr.contains("CHESTPLATE")){
+		if(matstr.contains("CHESTPLATE") || matstr.contains("ELYTRA")){
 			slot = 2;
 		}
 		if(matstr.contains("LEGGINGS")){


### PR DESCRIPTION
Added Elytra to the items for which getArmorSlot checks when looking for items to equip as armor